### PR TITLE
Restream: Bring back reader management

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,6 +163,13 @@
         "workspace": "1. GSPS - Ogólne"
       },
       {
+        "name": "reader",
+        "title": "Host",
+        "file": "reader.html",
+        "width": 4,
+        "workspace": "1. GSPS - Ogólne"
+      },
+      {
         "name": "next-run",
         "title": "Zmiana na przerwę",
         "file": "next-run.html",

--- a/src/browser/dashboard/reader.tsx
+++ b/src/browser/dashboard/reader.tsx
@@ -1,0 +1,89 @@
+import { DashboardThemeProvider } from './components/DashboardThemeProvider';
+import { render } from '../render';
+import { useReplicant } from 'use-nodecg';
+import {
+  Button,
+  FormControl,
+  Grid,
+  InputLabel,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { useEffect, useState } from 'react';
+import { Pronouns } from 'src/types/custom';
+import { pronouns as pronounsMap } from '../pronouns';
+import { Reader } from 'src/types/generated';
+
+export const App = () => {
+  const [reader, setReader] = useReplicant<Reader | undefined>('reader', undefined);
+  const [readerName, setReaderName] = useState('');
+  const [readerPronouns, setReaderPronouns] = useState<Pronouns>('');
+
+  useEffect(() => {
+    if (typeof reader === 'undefined') return;
+
+    setReaderName(reader.name);
+    setReaderPronouns(reader.pronouns);
+  }, [reader]);
+
+  return (
+    <DashboardThemeProvider>
+      <Stack spacing={1} useFlexGap>
+        <Typography variant="h6" style={{ marginBottom: '25px' }} align="center">
+          Obecny host:
+          {reader && (
+            <b>
+              <span> </span>
+              {reader.name} {reader.pronouns != '' && <>({reader.pronouns})</>}
+            </b>
+          )}
+        </Typography>
+        <Grid container spacing={2} style={{ width: '100%', marginBottom: '25px' }}>
+          <Grid item xs={7}>
+            <TextField
+              variant="outlined"
+              value={readerName}
+              onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                setReaderName(event.target.value);
+              }}
+              label="Nick hosta"
+              fullWidth
+            />
+          </Grid>
+          <Grid item xs={5}>
+            <FormControl fullWidth>
+              <InputLabel id="pronouns-select-label">Zaimki</InputLabel>
+              <Select
+                variant="outlined"
+                labelId="pronouns-select-label"
+                value={readerPronouns as string}
+                label="Zaimki"
+                onChange={(event: SelectChangeEvent) => {
+                  setReaderPronouns(event.target.value as Pronouns);
+                }}>
+                {Object.entries(pronounsMap).map((pronoun) => (
+                  <MenuItem key={pronoun[0]} value={pronoun[1]}>
+                    {pronoun[0]}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Grid>
+        </Grid>
+        <Button
+          variant="contained"
+          onClick={() => {
+            setReader({ name: readerName, pronouns: readerPronouns });
+          }}>
+          Aktualizuj nick hosta
+        </Button>
+      </Stack>
+    </DashboardThemeProvider>
+  );
+};
+
+render(<App />);

--- a/src/browser/graphics/components/reader.tsx
+++ b/src/browser/graphics/components/reader.tsx
@@ -40,7 +40,7 @@ const Reader = () => {
       {reader && reader.name.length > 0 && (
         <ReaderContainer>
           <ReaderLabel>
-            <p style={{ marginTop: '4px' }}>Czytający</p>
+            <p style={{ marginTop: '4px' }}>Host</p>
           </ReaderLabel>
           <ReaderName>
             <p style={{ marginTop: '3px' }}>


### PR DESCRIPTION
This brings back reader management to main tab because reader panel is not available when GDQ tracker integration is not configured