### PR TITLE
Introduce mixer integration

### DIFF
--- a/configschema.json
+++ b/configschema.json
@@ -208,6 +208,24 @@
       "description": "Info needed to control foobar2000.",
       "required": ["enabled"]
     },
+    "mixer": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "address": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer",
+          "default": 10024
+        }
+      },
+      "description": "Info needed to control mixer",
+      "required": ["enabled"]
+    },
     "footpedal": {
       "type": "object",
       "properties": {
@@ -270,6 +288,7 @@
     "donationSocket",
     "twitchExt",
     "sd",
-    "genericReplicant"
+    "genericReplicant",
+    "mixer"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "needle": "^3.2.0",
         "numeral": "^2.0.6",
         "obs-websocket-js": "^5.0.3",
+        "osc-js": "^2.4.1",
         "parse-ms": "^2.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -8991,6 +8992,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/osc-js": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/osc-js/-/osc-js-2.4.1.tgz",
+      "integrity": "sha512-QlSeRKJclL47FNvO1MUCAAp9frmCF9zcYbnf6R9HpcklAst8ZyX3ISsk1v/Vghr/5GmXn0bhVjFXF9h+hfnl4Q==",
+      "dependencies": {
+        "ws": "^8.16.0"
+      }
+    },
     "node_modules/osenv": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
@@ -12081,9 +12090,9 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "needle": "^3.2.0",
     "numeral": "^2.0.6",
     "obs-websocket-js": "^5.0.3",
+    "osc-js": "^2.4.1",
     "parse-ms": "^2.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/schemas/commentators.json
+++ b/schemas/commentators.json
@@ -23,9 +23,26 @@
           "onu/jegu",
           ""
         ]
+      },
+      "channel": {
+        "type": "string",
+        "enum": [
+          "",
+          "H1",
+          "H2",
+          "H3",
+          "H4",
+          "Host1",
+          "Host2",
+          "Host3",
+          "Donacje",
+          "Gra1",
+          "Gra2"
+        ],
+        "default": ""
       }
     },
-    "required": ["name", "pronouns"]
+    "required": ["name", "pronouns", "channel"]
   },
   "default": []
 }

--- a/src/browser/channels.ts
+++ b/src/browser/channels.ts
@@ -1,0 +1,13 @@
+export const channels = {
+  '(brak)': '',
+  'H1': 'H1',
+  'H2': 'H2',
+  'H3': 'H3',
+  'H4': 'H4',
+  'Host1': 'Host1',
+  'Host2': 'Host2',
+  'Host3': 'Host3',
+  'Donacje': 'Donacje',
+  'Gra1': 'Gra1',
+  'Gra2': 'Gra2',
+};

--- a/src/browser/dashboard/commentators.tsx
+++ b/src/browser/dashboard/commentators.tsx
@@ -17,8 +17,9 @@ import {
   TextField,
   Tooltip,
 } from '@mui/material';
-import { Pronouns } from 'src/types/custom';
+import { Pronouns, Channel } from 'src/types/custom';
 import { pronouns as pronounsMap } from '../pronouns';
+import { channels as channelsMap } from '../channels';
 import DeleteIcon from '@mui/icons-material/Delete';
 
 export const App = () => {
@@ -58,20 +59,32 @@ export const App = () => {
     setLocalCommentatorList(newState);
   }
 
+  function updateCommentatorChannel(commentatorIndex: number, channel: Channel) {
+    const newState = localCommentatorList.map((obj, index) => {
+      if (index === commentatorIndex) {
+        return { ...obj, channel: channel };
+      }
+
+      return obj;
+    });
+
+    setLocalCommentatorList(newState);
+  }
+
   return (
     <DashboardThemeProvider>
       <Stack spacing={2}>
         <Button
           variant="contained"
           onClick={() => {
-            setLocalCommentatorList([...localCommentatorList, { name: '', pronouns: '' }]);
+            setLocalCommentatorList([...localCommentatorList, { name: '', pronouns: '', channel: '' }]);
           }}>
           Dodaj komentatora
         </Button>
         {localCommentatorList.map((commentator, index) => (
           <div key={index}>
             <Grid container spacing={2} style={{ width: '100%', marginBottom: '25px' }}>
-              <Grid item xs={6.7}>
+              <Grid item xs={4.7}>
                 <TextField
                   variant="outlined"
                   value={commentator.name}
@@ -82,7 +95,7 @@ export const App = () => {
                   fullWidth
                 />
               </Grid>
-              <Grid item xs={4}>
+              <Grid item xs={3}>
                 <FormControl fullWidth>
                   <InputLabel id={`pronouns-select-label-${index}`}>Zaimki</InputLabel>
                   <Select
@@ -96,6 +109,25 @@ export const App = () => {
                     {Object.entries(pronounsMap).map((pronoun) => (
                       <MenuItem key={pronoun[0]} value={pronoun[1]}>
                         {pronoun[0]}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              </Grid>
+              <Grid item xs={3}>
+                <FormControl fullWidth>
+                  <InputLabel id={`channel-select-label-${index}`}>Kanał</InputLabel>
+                  <Select
+                    variant="outlined"
+                    labelId={`channel-select-label-${index}`}
+                    value={commentator.channel as string}
+                    label="Kanał"
+                    onChange={(event: SelectChangeEvent) => {
+                      updateCommentatorChannel(index, event.target.value as Channel);
+                    }}>
+                    {Object.entries(channelsMap).map((channel) => (
+                      <MenuItem key={channel[0]} value={channel[1]}>
+                        {channel[0]}
                       </MenuItem>
                     ))}
                   </Select>

--- a/src/browser/graphics/components/commentators.tsx
+++ b/src/browser/graphics/components/commentators.tsx
@@ -1,4 +1,5 @@
 import { Commentators as CommentatorsType } from 'src/types/generated';
+import { Channel } from 'src/types/custom';
 import styled from 'styled-components';
 import { useReplicant } from 'use-nodecg';
 
@@ -15,7 +16,6 @@ const CommentatorsLabel = styled.div`
 `;
 
 const CommentatorsNameContainer = styled.div<{ isOneCommentator: boolean }>`
-  background-color: rgba(0, 0, 0, 0.6);
   width: calc(100% - 140px);
   font-size: ${(props) => (props.isOneCommentator ? '20px' : '16px')};
   display: flex;
@@ -23,10 +23,12 @@ const CommentatorsNameContainer = styled.div<{ isOneCommentator: boolean }>`
   border-bottom: 2px solid #5f3ac2;
 `;
 
-const CommentatorName = styled.div<{ isLast: boolean }>`
+const CommentatorName = styled.div<{ isLast: boolean, signalLevel: number, thresholdLevel: number }>`
   flex: 1;
   text-align: center;
   border-right: ${(props) => (props.isLast ? '' : '2px solid #5f3ac2')};
+  background-color: ${(props) => ((props.signalLevel < props.thresholdLevel) ? 'rgba(0, 0, 0, 0.6)' : 'rgba(100, 100, 100, 0.6)')};
+  transition: ${(props) => ((props.signalLevel < props.thresholdLevel) ? 'background-color 1s ease-in-out 0.5s' : 'background-color 0.1s ease-in')};
 `;
 
 const Pronouns = styled.span`
@@ -42,6 +44,8 @@ const Pronouns = styled.span`
 
 const Commentators = () => {
   const [commentators] = useReplicant<CommentatorsType | undefined>('commentators', undefined);
+  const [mixerSignalLevels] = useReplicant<{ [key in Channel]: number } | undefined>("mixerSignalLevels", undefined);
+  const [mixerThresholdLevels] = useReplicant<{ [key in Channel]: number } | undefined>("mixerThresholdLevels", undefined);
 
   if (commentators && commentators.length) {
     return (
@@ -54,7 +58,11 @@ const Commentators = () => {
           </CommentatorsLabel>
           <CommentatorsNameContainer isOneCommentator={commentators.length === 1}>
             {commentators.map((commentator, index) => (
-              <CommentatorName key={commentator.name} isLast={commentators.length - 1 == index}>
+              <CommentatorName
+                key={commentator.name}
+                isLast={commentators.length - 1 == index}
+                signalLevel={mixerSignalLevels && mixerSignalLevels[commentator.channel] || -Infinity}
+                thresholdLevel={mixerThresholdLevels && mixerThresholdLevels[commentator.channel] || -Infinity}>
                 <p style={{ marginTop: commentators.length === 1 ? '3px' : '6px' }}>
                   {commentator.name}
                   {commentator.pronouns && <Pronouns>{commentator.pronouns}</Pronouns>}

--- a/src/browser/graphics/components/reader.tsx
+++ b/src/browser/graphics/components/reader.tsx
@@ -1,6 +1,7 @@
 import { Reader as ReaderType } from 'src/types/generated';
 import styled from 'styled-components';
 import { useReplicant } from 'use-nodecg';
+import { Channel } from 'src/types/custom';
 
 const ReaderContainer = styled.div`
   display: flex;
@@ -14,8 +15,9 @@ const ReaderLabel = styled.div`
   font-size: 18px;
 `;
 
-const ReaderName = styled.div`
-  background-color: rgba(0, 0, 0, 0.6);
+const ReaderName = styled.div<{ signalLevel: number, thresholdLevel: number }>`
+  background-color: ${(props) => ((props.signalLevel < props.thresholdLevel) ? 'rgba(0, 0, 0, 0.6)' : 'rgba(100, 100, 100, 0.6)')};
+  transition: ${(props) => ((props.signalLevel < props.thresholdLevel) ? 'background-color 1s ease-in-out 0.5s' : 'background-color 0.1s ease-in')};
   width: calc(100% - 140px);
   font-size: 20px;
   border-bottom: 2px solid #5f3ac2;
@@ -34,6 +36,8 @@ const Pronouns = styled.span`
 
 const Reader = () => {
   const [reader] = useReplicant<ReaderType | undefined>('reader', undefined);
+  const [mixerSignalLevels] = useReplicant<{ [key in Channel]: number } | undefined>("mixerSignalLevels", undefined);
+  const [mixerThresholdLevels] = useReplicant<{ [key in Channel]: number } | undefined>("mixerThresholdLevels", undefined);
 
   return (
     <>
@@ -42,7 +46,9 @@ const Reader = () => {
           <ReaderLabel>
             <p style={{ marginTop: '4px' }}>Host</p>
           </ReaderLabel>
-          <ReaderName>
+          <ReaderName
+            signalLevel={mixerSignalLevels ? mixerSignalLevels["Donacje"] : -Infinity}
+            thresholdLevel={mixerThresholdLevels ? mixerThresholdLevels["Donacje"] : -Infinity}>
             <p style={{ marginTop: '3px' }}>
               {reader.name} {reader.pronouns && <Pronouns>{reader.pronouns}</Pronouns>}
             </p>

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -23,4 +23,5 @@ export default (nodecg: NodeCG.ServerAPI<Configschema>) => {
   require('./timestamps');
   require('./total');
   require('./generic-replicant');
+  require('./mixer');
 };

--- a/src/extension/mixer.ts
+++ b/src/extension/mixer.ts
@@ -1,0 +1,150 @@
+import OSC from 'osc-js';
+import { get } from './util/nodecg';
+import { TaggedLogger } from './util/tagged-logger';
+import { Channel } from 'src/types/custom';
+
+const nodecg = get();
+
+const config = nodecg.bundleConfig.mixer;
+const log = new TaggedLogger('mixer');
+const channelIdToName = {
+  "1": "H1",
+  "2": "H2",
+  "3": "H3",
+  "4": "H4",
+  "9": "Host1",
+  "10": "Host2",
+  "16": "Host3",
+  "5": "Gra1",
+  "7": "Gra2",
+  "11": "Donacje",
+};
+const channelNameToId = Object.entries(channelIdToName).reduce((acc, [id, name]) => {
+  acc[name] = id;
+  return acc;
+}, {} as Record<string, string>);
+const mixerSignalLevels = nodecg.Replicant<{ [key in keyof typeof channelNameToId]: number }>('mixerSignalLevels', {
+  defaultValue: Object.keys(channelNameToId).reduce((acc, name) => {
+    acc[name] = -Infinity
+    return acc;
+  }, {"": -Infinity} as Record<string, number>)
+});
+
+// TODO add some panel to control them in case we need to tweak them live
+nodecg.Replicant<{ [key in keyof typeof channelNameToId]: number }>('mixerThresholdLevels', {
+  defaultValue: Object.keys(channelNameToId).reduce((acc, name) => {
+    acc[name] = -30
+    return acc;
+  }, {"": +Infinity} as Record<string, number>)
+});
+
+
+let osc : OSC | undefined = undefined;
+
+if (config.enabled) {
+  const settings = {
+    type: 'udp4',
+    open: {
+      host: '0.0.0.0',
+      port: 41234,
+      exclusive: true
+    },
+    send: {
+      host: config.address,
+      port: config.port,
+    }
+  }
+  osc = new OSC({ plugin: new OSC.DatagramPlugin(settings) })
+  osc.open()
+
+  osc.on("open", function () {
+    const xinfo = new OSC.Message("/xinfo")
+    osc!.send(xinfo);
+
+    scheduleMeters();
+  });
+
+  osc.on('error', (message: any) => {
+    log.error(message)
+  })
+
+  osc.on("/xinfo", function (message: any) {
+    log.info(`Connected to mixer: ${message.args}`);
+  })
+
+  osc.on("/meters/2", (message: any) => {
+    /* meters come as an array of u8. First there's an i32 that specifies the number of the i16 fields
+       that come afterwards. We can skip the first 4 bytes because the protocol limits the payload for us.
+       /meters/2 consists of 16 analog inputs, 2 aux inputs, and 18 usb inputs */
+    const u8Array = message.args[0];
+    const buffer = new DataView(u8Array.buffer, u8Array.byteOffset, u8Array.byteLength);
+    let i16Array = [];
+    for (let i = 4; i < buffer.byteLength; i += 2) {
+        i16Array.push(buffer.getInt16(i, true));
+    }
+    const analogIn = i16Array.slice(0, 16).map(meterToDb)
+    for (const [i, v] of analogIn.entries()) {
+      const channelId = (i + 1).toString();
+      const inputName = channelIdToName[channelId as keyof typeof channelIdToName] || channelId;
+      if (inputName != channelId) {
+        mixerSignalLevels.value![inputName as Channel] = v;
+      }
+    }
+  })
+
+  osc.on("*", function (message: any) {
+    if (message.address.startsWith("/meters")) {
+        return
+    }
+    log.debug(`catchall: ${message.address} ${message.args}`);
+  });
+
+  nodecg.listenFor('intermissionStarted', onIntermission);
+}
+
+function onIntermission() {
+  const channelsToMute = ['H1', 'H2', 'H3', 'H4', 'Gra1', 'Gra2', 'Host1', 'Host2', 'Host3'];
+  for (let channelName of channelsToMute) {
+    muteChannel(channelName);
+  }
+}
+
+function muteChannel(channelName: string) {
+  const channelId = channelNameToId[channelName];
+  if (channelId == undefined) {
+    log.error(`Can't find channel ${channelName}`)
+    return;
+  }
+  const padded = String(channelId).padStart(2, "0")
+
+  // alternatively we could mute via fader on main like:
+  // const command = new OSC.Message(`/ch/${padded}/mix/fader`, 0)
+
+  const command = new OSC.Message(`/ch/${padded}/mix/on`, 0)
+  log.debug(`Muting ${channelName} (${padded})`)
+  osc!.send(command);
+}
+
+function meterToDb(v: number): number {
+  return v / 256;
+}
+
+function scheduleMeters() {
+  /* There are multiple "meters" levels available, see "X AIR Remote Control Protocol.pdf"
+     on our drive https://drive.google.com/drive/folders/1Pmsiciq8zUkp-SP54CvPH52esTP2x7Id
+     for details. `/meters/2` gives us information about input signal levels for all channels.
+     Each activation of `/meters` command will result in 200 responses from the mixer.
+     We have to use the undocumented `/renew` to reset the counter on the device.
+     X AIR Edit does that roughly every 1 second, but that seems excessive. */
+
+  const meters = new OSC.Message("/meters", "/meters/2")
+  osc!.send(meters);
+
+  setInterval(() => {
+      const renewMeters = new OSC.Message("/renew", "/meters/2")
+      log.debug("renewing meters")
+      osc!.send(renewMeters);
+  }, 2000)
+}
+
+// TODO add a way to manually retrigger /meters/ in case udp drops the packet? button in panel? would we have to cancel the /renew?

--- a/src/extension/obs.ts
+++ b/src/extension/obs.ts
@@ -109,6 +109,7 @@ function reconnectToOBS() {
 function switchToIntermission() {
   if (obsDataReplicant.value?.scene === config.scenes!.intermission) return; // if we're already on intermission, don't do anything
 
+
   nodecg.sendMessageToBundle('changeToNextRun', 'nodecg-speedcontrol');
   if (!obsDataReplicant.value!.studioMode) {
     obs.call('SetStudioModeEnabled', { studioModeEnabled: true }).catch((err) => {
@@ -131,21 +132,17 @@ function switchToIntermission() {
   }
 
   obsDataReplicant.value!.scene = config.scenes!.intermission; // sometimes this isn't set automatically, setting it here just in case
-
   setTimeout(() => {
-    commentatorsReplicant.value = [];
-  }, config.stingerActionDelay);
-
-  nodecg.sendMessage('hideNames');
-  hosterkaReplicant.value = {
-    hostL: { name: '', pronouns: '' },
-    hostR: { name: '', pronouns: '' },
-  };
-  showBidsPanel.value = false;
-  showPrizePanel.value = false;
-
-  setTimeout(() => {
+    nodecg.sendMessage('hideNames');
+    hosterkaReplicant.value = {
+      hostL: { name: '', pronouns: '' },
+      hostR: { name: '', pronouns: '' },
+    };
+    showBidsPanel.value = false;
+    showPrizePanel.value = false;
     resetAllCrops();
+    commentatorsReplicant.value = [];
+    nodecg.sendMessage('intermissionStarted');
   }, config.stingerActionDelay);
 }
 

--- a/src/types/custom/channel.d.ts
+++ b/src/types/custom/channel.d.ts
@@ -1,0 +1,12 @@
+export type Channel =
+  | ''
+  | 'H1'
+  | 'H2'
+  | 'H3'
+  | 'H4'
+  | 'Host1'
+  | 'Host2'
+  | 'Host3'
+  | 'Donacje'
+  | 'Gra1'
+  | 'Gra2';

--- a/src/types/custom/index.d.ts
+++ b/src/types/custom/index.d.ts
@@ -15,3 +15,4 @@ export * from './mediaBoxItem';
 export * from './host';
 export * from './runCustomData';
 export * from './genericReplicant';
+export * from './channel';

--- a/src/types/generated/commentators.d.ts
+++ b/src/types/generated/commentators.d.ts
@@ -21,4 +21,5 @@ export type Commentators = {
 		| 'ne/nego'
 		| 'onu/jegu'
 		| '';
+	channel: '' | 'H1' | 'H2' | 'H3' | 'H4' | 'Host1' | 'Host2' | 'Host3' | 'Donacje' | 'Gra1' | 'Gra2';
 }[];

--- a/src/types/generated/configschema.d.ts
+++ b/src/types/generated/configschema.d.ts
@@ -80,6 +80,15 @@ export interface Configschema {
 		musicKeyword?: string;
 		[k: string]: unknown;
 	};
+	/**
+	 * Info needed to control mixer
+	 */
+	mixer: {
+		enabled: boolean;
+		address?: string;
+		port?: number;
+		[k: string]: unknown;
+	};
 	footpedal: {
 		enabled: boolean;
 		[k: string]: unknown;


### PR DESCRIPTION
Added:
- mixer integration uses OSC protocol via osc-js package
- we now emit a `intermissionStarted` event when in the middle of the stinger for intermission
- using the `intermissionStarted` we mute headsets, games and hosts on the mixer
- host and commentators are now highlighted when they talk

There are couple TODOs left, but I think they can be done in separate PRs:
- we probably need some way to control threshold levels per channel in case someone is very loud or there's a lot of noise
- we might need to retrigger the meters from the mixer in case of lost packet or mixer crash/restart/whatever