### PR TITLE
Adjust omnibars and intermission ticker for restream needs

### DIFF
--- a/src/browser/graphics/components/omnibar/ticker.tsx
+++ b/src/browser/graphics/components/omnibar/ticker.tsx
@@ -17,59 +17,44 @@ const Ticker = () => {
   const [currentElement, setCurrentElement] = useState<React.JSX.Element | undefined>(undefined);
   const [timestamp, setTimestamp] = useState(Date.now());
   let currentComponentIndex = 0;
+  let messageTypes: JSX.Element[] = [];
+
 
   function genericMsg(message: string) {
     return <GenericMessage message={message} onEnd={showNextElement} />;
   }
 
-  function gspsPromo() {
-    return genericMsg(
-      'Oglądacie&nbsp;<b class="highlight">Gramy Szybko, Pomagamy Skutecznie Dzieciom 2025</b>!'
-    );
-  }
+  messageTypes.push(
+    genericMsg(
+      'Witajcie na kanale&nbsp;<b class="highlight">Gramy Szybko, Pomagamy Skutecznie</b>!'
+    )
+  );
 
-  function charityPromo() {
-    return genericMsg(
-      'GSPS Dzieciom 2025 wspiera&nbsp;<b class="highlight">Fundację Na Ratunek Dzieciom z Chorobą Nowotworową</b>!'
-    );
-  }
+  messageTypes.push(
+    genericMsg(
+      'Dołącz do naszej społeczności na Discordzie na <b class="highlight">gsps.pl/discord</b>!'
+    )
+  );
 
-  function donationURL() {
-    return genericMsg('Wesprzyj na&nbsp;<b class="highlight">gsps.pl/wesprzyj</b>!');
-  }
+  messageTypes.push(
+    genericMsg(
+      'Więcej o wydarzeniach z serii GSPS możecie się dowiedzieć na <b class="highlight">gsps.pl</b>!'
+    )
+  );
 
-  function sponsor() {
-    return genericMsg(
-      'Zgarnij kod na&nbsp;<b class="highlight">20 zł do InPost Pay</b> — wpisz na czacie&nbsp;<b class="highlight">!kody</b>'
-    );
-  }
+  messageTypes.push(
+    genericMsg(
+      'Fundację GSPS możecie wesprzeć na&nbsp;<b class="highlight">gsps.pl/wesprzyj</b>!'
+    )
+  )
 
-  function nextRuns() {
-    return <NextRuns onEnd={showNextElement} />;
+  // TODO make configurable
+  if (false) {
+    messageTypes.push(<NextRuns onEnd={showNextElement} />);
+    messageTypes.push(<Bids onEnd={showNextElement} />);
+    messageTypes.push(<Prizes onEnd={showNextElement} />);
+    messageTypes.push(<Milestones onEnd={showNextElement} />);
   }
-
-  function bids() {
-    return <Bids onEnd={showNextElement} />;
-  }
-
-  function prizes() {
-    return <Prizes onEnd={showNextElement} />;
-  }
-
-  function milestones() {
-    return <Milestones onEnd={showNextElement} />;
-  }
-
-  const messageTypes = [
-    gspsPromo(),
-    charityPromo(),
-    donationURL(),
-    nextRuns(),
-    bids(),
-    prizes(),
-    milestones(),
-    sponsor(),
-  ];
 
   function showNextElement() {
     console.log('SHOWING NEXT MESSAGE');

--- a/src/browser/graphics/components/przerwa/omnibar.tsx
+++ b/src/browser/graphics/components/przerwa/omnibar.tsx
@@ -33,38 +33,38 @@ const Ticker = () => {
   const [currentElement, setCurrentElement] = useState<React.JSX.Element | undefined>(undefined);
   const [timestamp, setTimestamp] = useState(Date.now());
   let currentComponentIndex = 0;
+  let enableMilestones = false; // TODO: make configurable
+  let enableCharity = false; // TODO: make configurable
+  let messageTypes: JSX.Element[] = [];
 
   function genericMsg(message: string) {
     return <GenericMessage message={message} onEnd={showNextElement} />;
   }
 
-  function gspsPromo() {
-    return genericMsg(
-      'Oglądacie&nbsp;<b class="highlight">Gramy Szybko, Pomagamy Skutecznie Dzieciom 2025</b>!'
+  messageTypes.push(
+    genericMsg(
+      'Witajcie na kanale&nbsp;<b class="highlight">Gramy Szybko, Pomagamy Skutecznie</b>!'
+    )
+  );
+
+  if (enableCharity) {
+    // TODO make the text configurable
+    messageTypes.push(
+      genericMsg(
+        'GSPS Dzieciom 2025 wspiera&nbsp;<b class="highlight">Fundację Na Ratunek Dzieciom z Chorobą Nowotworową</b>!'
+      )
     );
   }
 
-  function charityPromo() {
-    return genericMsg(
-      'GSPS Dzieciom 2025 wspiera&nbsp;<b class="highlight">Fundację Na Ratunek Dzieciom z Chorobą Nowotworową</b>!'
-    );
+  // TODO: make configurable
+  messageTypes.push(
+    genericMsg('Możecie wesprzeć fundację GSPS bezpośrednio na &nbsp;<b class="highlight">gsps.pl/wesprzyj</b>!')
+  );
+
+  if (enableMilestones) {
+    messageTypes.push(<Milestones onEnd={showNextElement} />);
   }
 
-  function donationURL() {
-    return genericMsg('Wesprzyj na&nbsp;<b class="highlight">gsps.pl/wesprzyj</b>!');
-  }
-
-  function sponsor() {
-    return genericMsg(
-      'Zgarnij kod na&nbsp;<b class="highlight">20 zł do InPost Pay</b> — wpisz na czacie&nbsp;<b class="highlight">!kody</b>'
-    );
-  }
-
-  function milestones() {
-    return <Milestones onEnd={showNextElement} />;
-  }
-
-  const messageTypes = [gspsPromo(), charityPromo(), donationURL(), milestones(), sponsor()];
 
   function showNextElement() {
     console.log('SHOWING NEXT MESSAGE');

--- a/src/browser/graphics/components/przerwa/ticker.tsx
+++ b/src/browser/graphics/components/przerwa/ticker.tsx
@@ -26,6 +26,7 @@ const BreakTicker = () => {
   const [currentElement, setCurrentElement] = useState<JSX.Element | undefined>(undefined);
   const [timestamp, setTimestamp] = useState(Date.now());
   let currentComponentIndex = 0;
+  let enableTicker = false; // TODO: make configurable or figure out a way to not busy loop when empty
 
   function prizes() {
     return <Prizes onEnd={showNextElement} />;
@@ -35,7 +36,13 @@ const BreakTicker = () => {
     return <Bids onEnd={showNextElement} />;
   }
 
-  const messageTypes = [bids(), prizes()];
+  let messageTypes: JSX.Element[] = [];
+  if (enableTicker) {
+    messageTypes = [bids(), prizes()];
+  } else {
+    messageTypes = [];
+  }
+
 
   function showNextElement() {
     console.log('SHOWING NEXT MESSAGE');


### PR DESCRIPTION
Currently omnibars from `restream` have been ported with some preliminary work towards making them configurable in the future so that no changes in code are needed to update them.

Intermission ticker has been disabled because it's busy-looping when there are no bids and prizes.