### PR TITLE
Update reader panel

### DIFF
--- a/src/browser/dashboard/reader-panel.tsx
+++ b/src/browser/dashboard/reader-panel.tsx
@@ -821,7 +821,7 @@ const Donation = ({
             </p>
             <p>{donation.comment}</p>
           </div>
-          {donation.bid && donation.bid.length && (
+          {(donation.bid && donation.bid.length && (
             <>
               <p>
                 <b>Licytacje</b>
@@ -834,7 +834,7 @@ const Donation = ({
                 );
               })}
             </>
-          )}
+          )) || ''}
           <Button
             sx={{ width: '100%' }}
             variant="contained"

--- a/src/extension/donations-prizes.ts
+++ b/src/extension/donations-prizes.ts
@@ -179,7 +179,7 @@ async function setDonationAsRead(id: number, name: string, amount: number): Prom
   try {
     const resp = await needle(
       'get',
-      `${rootURL}/edit?type=donation&id=${id}` + '&readstate=READ&commentstate=APPROVED',
+      `${rootURL}/edit?type=donation&id=${id}` + '&readstate=READ',
       {
         cookies: cookies,
       }


### PR DESCRIPTION
This PR fixes 2 bugs:

- Hide 0 when there are no bids attached to the donation
    
    There used to be a dangling `0` displayed just before the button to mark
    the donation as read when there was no bids attached to the given donation.

- Don't accept donation comments while marking them as read
    
    This would lead to exposing comments that were moderated out